### PR TITLE
Remove old dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,0 @@
-version: 1
-
-update_configs:
-  - package_manager: javascript
-    directory: /
-    update_schedule: live
-    allowed_updates:
-      - match:
-          update_type: "security"


### PR DESCRIPTION
Removing the old dependabot config. Since we only were doing security scanning that is now handled in the repo settings and not a direct file.

Removing this config as it's no longer needed.